### PR TITLE
Very minor fix to make ImGui happy

### DIFF
--- a/application/src/cpu_widget.cpp
+++ b/application/src/cpu_widget.cpp
@@ -102,7 +102,7 @@ void CpuWidget::draw() {
     }
     ImGui::SameLine();
     ImGui::SetNextItemWidth(button_size.x);
-    ImGui::InputScalar("",
+    ImGui::InputScalar("##CpuInputScalar",
             ImGuiDataType_U16,
             &jump_to_address_,
             nullptr,


### PR DESCRIPTION
I ran into this issue when running the application on my linux system:

n_e_s_vis_app: /home/ubuntu/dev/garage/n_e_s_vis/build/_deps/imgui-src/imgui.cpp:8940: bool ImGui::ItemAdd(const ImRect&, ImGuiID, const ImRect*, ImGuiItemFlags): Assertion `id != window->ID && "Cannot have an empty ID at the root of a window. If you need an empty label, use ## and read the FAQ about how the ID Stack works!"' failed

It was easily fixed, just had to give it an ID; thought perhaps you'd be interested in this PR!