### PR TITLE
Use bazelbuild/platforms instead of platforms from bazel_tools

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,15 @@ load(
     "http_archive",
 )
 
+http_archive(
+    name = "platforms",
+    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+    ],
+)
+
 git_repository(
     name = "nes",
     commit = "0ae36a8d27562c15ed2ef90776b939030d0ff9ca",

--- a/extlibs/BUILD.imgui-sfml
+++ b/extlibs/BUILD.imgui-sfml
@@ -11,7 +11,7 @@ cc_library(
         "imgui-SFML_export.h",
     ],
     linkopts = select({
-        "@bazel_tools//platforms:windows": [
+        "@platforms//os:windows": [
             "-DEFAULTLIB:opengl32",
         ],
         "//conditions:default": [

--- a/extlibs/BUILD.sfml
+++ b/extlibs/BUILD.sfml
@@ -12,18 +12,18 @@ cc_library(
 cc_library(
     name = "ft2",
     srcs = select({
-        "@bazel_tools//platforms:windows": [
+        "@platforms//os:windows": [
             "extlibs/libs-msvc/x64/freetype.lib",
         ],
-        "@bazel_tools//platforms:linux": []
+        "@platforms//os:linux": []
     }),
     hdrs = glob([
         "extlibs/headers/freetype2/**/*.h",
     ]),
     linkopts = select({
-        "@bazel_tools//platforms:windows": [
+        "@platforms//os:windows": [
         ],
-        "@bazel_tools//platforms:linux": [
+        "@platforms//os:linux": [
             "-lfreetype",
         ],
     }),
@@ -35,11 +35,11 @@ cc_library(
     srcs = glob([
         "src/SFML/System/*.cpp",
     ]) + select({
-        "@bazel_tools//platforms:windows": glob([
+        "@platforms//os:windows": glob([
             "src/SFML/System/Win32/**/*.cpp",
             "src/SFML/System/Win32/**/*.hpp",
         ]),
-        "@bazel_tools//platforms:linux": glob([
+        "@platforms//os:linux": glob([
             "src/SFML/System/Unix/**/*.cpp",
             "src/SFML/System/Unix/**/*.hpp",
         ]),
@@ -52,10 +52,10 @@ cc_library(
     copts = ["-Iexternal/sfml/src/"],
     defines = ["SFML_STATIC"],
     linkopts = select({
-        "@bazel_tools//platforms:windows": [
+        "@platforms//os:windows": [
             "-DEFAULTLIB:winmm",
         ],
-        "@bazel_tools//platforms:linux": [
+        "@platforms//os:linux": [
             "-ludev",
             "-pthread",
         ],
@@ -78,11 +78,11 @@ cc_library(
             "src/SFML/Window/EGLCheck.hpp",
         ],
     ) + select({
-        "@bazel_tools//platforms:windows": glob([
+        "@platforms//os:windows": glob([
             "src/SFML/Window/Win32/**/*.cpp",
             "src/SFML/Window/Win32/**/*.hpp",
         ]),
-        "@bazel_tools//platforms:linux": glob([
+        "@platforms//os:linux": glob([
             "src/SFML/Window/Unix/**/*.cpp",
             "src/SFML/Window/Unix/**/*.hpp",
         ]),
@@ -97,14 +97,14 @@ cc_library(
         "_UNICODE",
     ],
     linkopts = select({
-        "@bazel_tools//platforms:windows": [
+        "@platforms//os:windows": [
             "-DEFAULTLIB:advapi32",
             "-DEFAULTLIB:gdi32",
             "-DEFAULTLIB:opengl32",
             "-DEFAULTLIB:user32",
             "-DEFAULTLIB:winmm",
         ],
-        "@bazel_tools//platforms:linux": [
+        "@platforms//os:linux": [
             "-lGL",
             "-lX11",
             "-lXrandr",
@@ -130,10 +130,10 @@ cc_library(
     copts = ["-Iexternal/sfml/src/"],
     defines = ["SFML_STATIC"],
     linkopts = select({
-        "@bazel_tools//platforms:windows": [
+        "@platforms//os:windows": [
             "-DEFAULTLIB:opengl32",
         ],
-        "@bazel_tools//platforms:linux": [
+        "@platforms//os:linux": [
             "-lGL",
             "-ludev",
             "-pthread",


### PR DESCRIPTION
* Required in bazel 6.0.0.